### PR TITLE
Added CAUTION note about case sensitive queries

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,10 @@ removing the vowels.
 * `minLength` is the minimum number of characters for the shorted url.
 * `shortDomain` the short domain for your url shortener.
 
+CAUTION: If you include both lowercase and uppercase characters in the `characters` list you must make sure your
+database/table is configured to do **case sensitive** queries. Otherwise you could get the wrong URL back when
+querying the database.
+
 Next you have to provide a unique number generator. The plugin provides an in-memory dummy implementation using
 AtomicLong available in the file https://github.com/lmivan/grails-url-shortener/blob/master/src/groovy/net/kaleidos/shortener/generator/DummySequenceGenerator.groovy[DummySequenceGenerator].
 


### PR DESCRIPTION
I learned this lesson the hard way! :-) Our production MySQL is case insensitive and we started to get mixed up short URLs.

We modified the short_url column to be case sensitive and removed all lowercase letters from 'characters list. This fixes existing URL queries and make sure new URL only get uppercase letters.

```
alter table shorten_url modify short_url varchar(255) binary not null;
```

A CAUTION note in the docs hopefully helps people avoid my mistake.
